### PR TITLE
fix: Catch broader pid exceptions in entity resolver

### DIFF
--- a/oarepo_requests/services/ui_schema.py
+++ b/oarepo_requests/services/ui_schema.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 
 import marshmallow as ma
-from invenio_pidstore.errors import PIDDeletedError
+from invenio_pidstore.errors import PersistentIdentifierError, PIDDeletedError
 from invenio_requests.proxies import current_request_type_registry, current_requests
 from invenio_requests.resolvers.registry import ResolverRegistry
 from invenio_requests.services.schemas import (
@@ -40,6 +40,8 @@ class UIReferenceSchema(ma.Schema):
                 return resolve(self.context["identity"], data["reference"])
             except PIDDeletedError:
                 return {**data, "status": "removed"}
+            except PersistentIdentifierError:
+                return {**data, "status": "invalid"}
         resolved_cache = self.context["resolved"]
         return resolved_cache.dereference(data["reference"])
 
@@ -99,7 +101,7 @@ class UIRequestSchemaMixin:
                         # not very nice, but we need to pass the request object to the stateful_description function
                         request=SimpleNamespace(**data),
                     )
-        except PIDDeletedError:
+        except PersistentIdentifierError:
             pass
 
         return stateful_name, stateful_description

--- a/oarepo_requests/utils.py
+++ b/oarepo_requests/utils.py
@@ -1,4 +1,5 @@
 from invenio_access.permissions import system_identity
+from invenio_pidstore.errors import PersistentIdentifierError
 from invenio_records_resources.proxies import current_service_registry
 from invenio_requests.proxies import (
     current_request_type_registry,
@@ -184,7 +185,10 @@ def request_identity_matches(entity_reference, identity):
     if not entity_reference:
         return False
 
-    entity = ResolverRegistry.resolve_entity_proxy(entity_reference)
-    if entity:
-        needs = entity.get_needs()
-        return bool(identity.provides.intersection(needs))
+    try:
+        entity = ResolverRegistry.resolve_entity_proxy(entity_reference)
+        if entity:
+            needs = entity.get_needs()
+            return bool(identity.provides.intersection(needs))
+    except PersistentIdentifierError:
+        return False


### PR DESCRIPTION
To not fail on PID deleted and invalid errors