### PR TITLE
Support per-type default request receiver

### DIFF
--- a/oarepo_requests/actions/components.py
+++ b/oarepo_requests/actions/components.py
@@ -256,7 +256,7 @@ class AutoAcceptComponent(RequestActionComponent):
         if action.request.status != "submitted":
             return
         receiver_ref = action.request.receiver  # this is <x>proxy, not dict
-        if not receiver_ref.reference_dict.get("auto_approve"):
+        if receiver_ref is not None and not receiver_ref.reference_dict.get("auto_approve"):
             return
 
         action_obj = RequestActions.get_action(action.request, "accept")

--- a/oarepo_requests/actions/components.py
+++ b/oarepo_requests/actions/components.py
@@ -256,7 +256,7 @@ class AutoAcceptComponent(RequestActionComponent):
         if action.request.status != "submitted":
             return
         receiver_ref = action.request.receiver  # this is <x>proxy, not dict
-        if receiver_ref is not None and not receiver_ref.reference_dict.get("auto_approve"):
+        if receiver_ref is None or not receiver_ref.reference_dict.get("auto_approve"):
             return
 
         action_obj = RequestActions.get_action(action.request, "accept")

--- a/oarepo_requests/services/oarepo/service.py
+++ b/oarepo_requests/services/oarepo/service.py
@@ -24,6 +24,7 @@ from oarepo_requests.services.results import (
     RequestTypesList,
     StringEntityResolverExpandableField,
 )
+from oarepo_requests.types import DefaultReceiverMixin
 from oarepo_requests.utils import (
     allowed_request_types_for_record,
     resolve_reference_dict,
@@ -96,10 +97,13 @@ class OARepoRequestsService(RequestsService):
             raise UnknownRequestTypeError(request_type)
         data = data or {}
         if receiver is None:
-            # if explicit creator is not passed, use current identity - this is in sync with invenio_requests
-            receiver = current_oarepo_requests.default_request_receiver(
-                identity, type_, topic, creator or identity, data
-            )
+            if isinstance(request_type, DefaultReceiverMixin):
+                receiver = request_type.default_request_receiver(identity, topic, creator or identity, data)
+            else:
+                # if explicit creator is not passed, use current identity - this is in sync with invenio_requests
+                receiver = current_oarepo_requests.default_request_receiver(
+                    identity, type_, topic, creator or identity, data
+                )
         if "payload" not in data and type_.payload_schema:
             data["payload"] = {}
         schema = self._wrap_schema(type_.marshmallow_schema())

--- a/oarepo_requests/services/oarepo/service.py
+++ b/oarepo_requests/services/oarepo/service.py
@@ -114,7 +114,7 @@ class OARepoRequestsService(RequestsService):
         )
         if hasattr(type_, "can_create"):
             # raise exception if can't
-            type_.can_create(identity, data, receiver, topic, creator)
+            type_.can_create(identity, data, receiver, topic, creator)  # type: ignore[reportAttributeAccessIssue]
         # TODO: typing does not allow receiver to be None even though invenio code suggests it
         result = super().create(
             identity=identity,

--- a/oarepo_requests/services/oarepo/service.py
+++ b/oarepo_requests/services/oarepo/service.py
@@ -97,8 +97,8 @@ class OARepoRequestsService(RequestsService):
             raise UnknownRequestTypeError(request_type)
         data = data or {}
         if receiver is None:
-            if isinstance(request_type, DefaultReceiverMixin):
-                receiver = request_type.default_request_receiver(identity, topic, creator or identity, data)
+            if isinstance(type_, DefaultReceiverMixin):
+                receiver = type_.default_request_receiver(identity, topic, creator or identity, data)
             else:
                 # if explicit creator is not passed, use current identity - this is in sync with invenio_requests
                 receiver = current_oarepo_requests.default_request_receiver(

--- a/oarepo_requests/types/__init__.py
+++ b/oarepo_requests/types/__init__.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 from .delete_published_record import DeletePublishedRecordRequestType
 from .edit_record import EditPublishedRecordRequestType
-from .generic import NonDuplicableOARepoRecordRequestType
+from .generic import DefaultReceiverMixin, NonDuplicableOARepoRecordRequestType, OARepoRequestType
 from .publish_draft import PublishDraftRequestType
 
 __all__ = [
+    "DefaultReceiverMixin",
     "DeletePublishedRecordRequestType",
     "EditPublishedRecordRequestType",
     "NonDuplicableOARepoRecordRequestType",
+    "OARepoRequestType",
     "PublishDraftRequestType",
 ]

--- a/oarepo_requests/types/generic.py
+++ b/oarepo_requests/types/generic.py
@@ -43,9 +43,12 @@ if TYPE_CHECKING:
     from flask_babel.speaklater import LazyString
     from flask_principal import Identity
     from invenio_records_resources.records import Record
+    from invenio_requests.customizations import RequestType as TypingMixinRequestType
     from invenio_requests.customizations.actions import RequestAction
     from invenio_requests.records.api import Request
     from marshmallow.schema import Schema
+else:
+    TypingMixinRequestType = object
 
 
 class OARepoRequestType(RequestType):
@@ -335,7 +338,7 @@ class NonDuplicableOARepoRecordRequestType(OARepoRecordRequestType):
         return super().is_applicable_to(identity, topic, *args, **kwargs)
 
 
-class DefaultReceiverMixin:
+class DefaultReceiverMixin(TypingMixinRequestType):
     """Mixin for request types that have a default request receiver."""
 
     @classmethod

--- a/oarepo_requests/types/generic.py
+++ b/oarepo_requests/types/generic.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, cast
 
 from invenio_records_resources.services.errors import PermissionDeniedError
@@ -332,3 +333,18 @@ class NonDuplicableOARepoRecordRequestType(OARepoRecordRequestType):
         if open_request_exists(topic, cls.type_id):
             return False
         return super().is_applicable_to(identity, topic, *args, **kwargs)
+
+
+class DefaultReceiverMixin:
+    """Mixin for request types that have a default request receiver."""
+
+    @classmethod
+    @abstractmethod
+    def default_request_receiver(
+        cls,
+        identity: Identity,
+        topic: Record,
+        creator: dict[str, str] | Identity,
+        data: dict,
+    ) -> dict[str, str] | None:
+        """Return the default request receiver."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,11 +316,6 @@ class DefaultRequests(WorkflowRequestPolicy):
         recipients=[AutoApprove()],
         transitions=WorkflowTransitions(),
     )
-    no_receiver_rt = WorkflowRequest(
-        requesters=[AuthenticatedUser()],
-        recipients=[],
-        transitions=WorkflowTransitions(),
-    )
 
 
 class PublishAutoAcceptRequests(DefaultRequests):
@@ -559,6 +554,16 @@ class RequestsWithSystemIdentity(WorkflowRequestPolicy):
     )
 
 
+class RequestsWithNoRecipients(WorkflowRequestPolicy):
+    """Test requests workflow with publish only by system identity."""
+
+    no_receiver_rt = WorkflowRequest(
+        requesters=[AuthenticatedUser()],
+        recipients=[],
+        transitions=WorkflowTransitions(),
+    )
+
+
 class TestWorkflowPermissions(RequestBasedWorkflowPermissions):
     """Default workflow permissions for testing."""
 
@@ -604,6 +609,12 @@ WORKFLOWS = [
         label=_("Default workflow"),
         permission_policy_cls=TestWorkflowPermissions,
         request_policy_cls=DefaultRequests,
+    ),
+    Workflow(
+        code="no_receiver",
+        label=_("Workflow with no receiver"),
+        permission_policy_cls=TestWorkflowPermissions,
+        request_policy_cls=RequestsWithNoRecipients,
     ),
     Workflow(
         code="with_approve",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import contextlib
 import os
 import time
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, override
 
 import pytest
 from flask import Blueprint
@@ -66,10 +66,13 @@ from oarepo_requests.services.permissions.workflow_policies import (
     RequestBasedWorkflowPermissions,
 )
 from oarepo_requests.types import (
+    DefaultReceiverMixin,
     NonDuplicableOARepoRecordRequestType,
 )
 
 if TYPE_CHECKING:
+    from flask_principal import Identity
+    from invenio_records.api import Record
     from invenio_requests.customizations.actions import RequestAction
     from invenio_requests.records.api import Request
 
@@ -221,6 +224,25 @@ class ConditionalRecipientRecordRequestType(NonDuplicableOARepoRecordRequestType
     allowed_on_published = False
 
 
+class NoReceiverRequestType(DefaultReceiverMixin, NonDuplicableOARepoRecordRequestType):
+    """Request type with no receiver."""
+
+    type_id = "no_receiver_rt"
+    name = _("Request type to test no receiver")
+    receiver_can_be_none = True
+
+    @override
+    @classmethod
+    def default_request_receiver(
+        cls,
+        identity: Identity,
+        topic: Record,
+        creator: dict[str, str] | Identity,
+        data: dict,
+    ) -> None:
+        """Return None."""
+
+
 class DefaultRequests(WorkflowRequestPolicy):
     """Default test requests workflow."""
 
@@ -292,6 +314,11 @@ class DefaultRequests(WorkflowRequestPolicy):
     new_version = WorkflowRequest(
         requesters=[IfNoNewVersionDraft([IfInState("published", [RecordOwners()])])],
         recipients=[AutoApprove()],
+        transitions=WorkflowTransitions(),
+    )
+    no_receiver_rt = WorkflowRequest(
+        requesters=[AuthenticatedUser()],
+        recipients=[],
         transitions=WorkflowTransitions(),
     )
 
@@ -747,6 +774,7 @@ def app_config(app_config, requests_model):
         ConditionalRecipientRecordRequestType(),
         AnotherTopicUpdatingRecordRequestType(),
         GenericTestableRecordRequestType(),
+        NoReceiverRequestType(),
     ]
     app_config["FILES_REST_STORAGE_CLASS_LIST"] = {
         "L": "Local",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -555,7 +555,7 @@ class RequestsWithSystemIdentity(WorkflowRequestPolicy):
 
 
 class RequestsWithNoRecipients(WorkflowRequestPolicy):
-    """Test requests workflow with publish only by system identity."""
+    """Test requests workflow with no recipients."""
 
     no_receiver_rt = WorkflowRequest(
         requesters=[AuthenticatedUser()],

--- a/tests/test_requests/test_default_recipient_method.py
+++ b/tests/test_requests/test_default_recipient_method.py
@@ -23,7 +23,7 @@ def test_default_recipient_method(
 ):
     creator = users[0]
 
-    draft1 = draft_factory(creator.identity)
+    draft1 = draft_factory(creator.identity, custom_workflow="no_receiver")
     draft1_id = draft1["id"]
     requests_model.Record.index.refresh()
     requests_model.Draft.index.refresh()

--- a/tests/test_requests/test_default_recipient_method.py
+++ b/tests/test_requests/test_default_recipient_method.py
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2024 CESNET z.s.p.o.
+#
+# oarepo-requests is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+#
+
+
+from __future__ import annotations
+
+
+def test_default_recipient_method(
+    requests_model,
+    logged_client,
+    users,
+    urls,
+    submit_request_on_draft,
+    create_request_on_draft,
+    draft_factory,
+    link2testclient,
+    search_clear,
+):
+    creator = users[0]
+
+    draft1 = draft_factory(creator.identity)
+    draft1_id = draft1["id"]
+    requests_model.Record.index.refresh()
+    requests_model.Draft.index.refresh()
+
+    req = submit_request_on_draft(creator.identity, draft1_id, "no_receiver_rt")
+    assert req["receiver"] is None


### PR DESCRIPTION
Add DefaultReceiverMixin and use it in OARepoRequestsService so request types can provide their own default receiver. Handle None receiver in AutoAcceptComponent to avoid attribute errors. Add NoReceiverRequestType and tests for the new behavior.