### PR TITLE
Major bump due to invenio bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-requests"
-version = "6.0.0"
+version = "7.0.0"
 description = "Extra requests for InvenioRDM ecosystem"
 readme = "README.md"
 authors = [
@@ -10,9 +10,9 @@ requires-python = ">=3.14,<3.15"
 
 dependencies = [
     "oarepo[rdm,tests]>=14.2.1b10.dev7,<15.0.0",
-    "oarepo-runtime>=4.0.0,<5.0.0",
-    "oarepo-model>=2.0.0,<3.0.0",
-    "oarepo-workflows>=4.0.0,<5.0.0",
+    "oarepo-runtime>=5.0.0,<6.0.0",
+    "oarepo-model>=3.0.0,<4.0.0",
+    "oarepo-workflows>=5.0.0,<6.0.0",
 
     # invenio dependencies
     "invenio-app-rdm>=14.0.0b10.dev5,<15.0.0",
@@ -32,8 +32,8 @@ dev = [
 
 tests = [
     "pytest-invenio>=4.0.0,<5.0.0",
-    "pytest-oarepo>=4.0.0,<5.0.0",
-    "oarepo-rdm>=4.0.0,<5.0.0",
+    "pytest-oarepo>=5.0.0,<6.0.0",
+    "oarepo-rdm>=6.0.0,<7.0.0",
     "deepdiff",
 ]
 oarepo14 = [


### PR DESCRIPTION
Major version bump due to major bump in packages: oarepo-model, oarepo-runtime, pytest-oarepo, oarepo-rdm, oarepo-workflows.

## Included pull requests

- [breaking] using vnd serialization for dashboard requests ([#186](https://github.com/oarepo/oarepo-requests/pull/186))
