### PR TITLE
Major version bump due to major bump in packages: invenio-rdm-records

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-requests"
-version = "8.1.0"
+version = "9.0.0"
 description = "Extra requests for InvenioRDM ecosystem"
 readme = "README.md"
 authors = [
@@ -10,10 +10,10 @@ requires-python = ">=3.14,<3.15"
 
 dependencies = [
     "oarepo[rdm,tests]>=14.2.1b10.dev7,<15.0.0",
-    "oarepo-runtime>=6.0.0,<7.0.0",
-    "oarepo-model>=4.0.0,<5.0.0",
-    "oarepo-workflows>=6.0.0,<7.0.0",
-    "oarepo-ui>=12.0.0,<13.0.0",
+    "oarepo-runtime>=7.0.0,<8.0.0",
+    "oarepo-model>=5.0.0,<6.0.0",
+    "oarepo-workflows>=7.0.0,<8.0.0",
+    "oarepo-ui>=13.0.0,<14.0.0",
 
     # invenio dependencies
     "invenio-app-rdm>=14.0.0b10.dev5,<15.0.0",
@@ -34,7 +34,7 @@ dev = [
 tests = [
     "pytest-invenio>=4.0.0,<5.0.0",
     "pytest-oarepo>=6.0.0,<7.0.0",
-    "oarepo-rdm>=7.0.0,<8.0.0",
+    "oarepo-rdm>=8.0.0,<9.0.0",
     "deepdiff",
 ]
 oarepo14 = [


### PR DESCRIPTION
Major version bump due to major bump in packages: oarepo-runtime, oarepo-model, oarepo-ui, oarepo-rdm, oarepo-workflows.
