### PR TITLE
fix: resolving to draft topics in publish

### DIFF
--- a/oarepo_requests/types/__init__.py
+++ b/oarepo_requests/types/__init__.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 from .delete_published_record import DeletePublishedRecordRequestType
 from .edit_record import EditPublishedRecordRequestType
 from .generic import DefaultReceiverMixin, NonDuplicableOARepoRecordRequestType, OARepoRequestType
+from .publish_changed_metadata import PublishChangedMetadataRequestType
 from .publish_draft import PublishDraftRequestType
+from .publish_new_version import PublishNewVersionRequestType
 
 __all__ = [
     "DefaultReceiverMixin",
@@ -20,5 +22,7 @@ __all__ = [
     "EditPublishedRecordRequestType",
     "NonDuplicableOARepoRecordRequestType",
     "OARepoRequestType",
+    "PublishChangedMetadataRequestType",
     "PublishDraftRequestType",
+    "PublishNewVersionRequestType",
 ]

--- a/oarepo_requests/types/publish_base.py
+++ b/oarepo_requests/types/publish_base.py
@@ -9,12 +9,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, override
+from typing import TYPE_CHECKING, Any, Literal, cast, override
 
 import marshmallow as ma
+from invenio_drafts_resources.records import Draft
 from invenio_drafts_resources.records import Record as RecordWithDraft
 from invenio_i18n import gettext
 from invenio_i18n import lazy_gettext as _
+from oarepo_runtime.proxies import current_runtime
+from oarepo_runtime.typing import record_from_result
 
 from oarepo_requests.actions.publish_draft import (
     PublishDraftAcceptAction,
@@ -27,6 +30,7 @@ from .generic import NonDuplicableOARepoRecordRequestType
 
 if TYPE_CHECKING:
     from flask_principal import Identity
+    from invenio_drafts_resources.services import RecordService
     from invenio_records_resources.records import Record
     from invenio_requests.customizations.actions import RequestAction
     from invenio_requests.records.api import Request
@@ -71,8 +75,7 @@ class PublishRequestType(NonDuplicableOARepoRecordRequestType):
         **kwargs: Any,
     ) -> None:
         """Check if the request can be created."""
-        if not isinstance(topic, RecordWithDraft):
-            raise TypeError(f"Topic type {type(topic)} does not support drafts")
+        topic = self._convert_to_draft(identity, topic)
         self.assert_no_pending_requests(topic)
         super().can_create(identity, data, receiver, topic, creator, *args, **kwargs)
         self.validate_topic(identity, topic)
@@ -81,9 +84,21 @@ class PublishRequestType(NonDuplicableOARepoRecordRequestType):
     @override
     def is_applicable_to(cls, identity: Identity, topic: Record, *args: Any, **kwargs: Any) -> bool:
         """Check if the request type is applicable to the topic."""
+        topic = cls._convert_to_draft(identity, topic)
+        return super().is_applicable_to(identity, topic, *args, **kwargs)
+
+    @classmethod
+    def _convert_to_draft(cls, identity: Identity, topic: Record) -> Draft:
+        """Convert the topic to a draft."""
         if not isinstance(topic, RecordWithDraft):
             raise TypeError(f"Topic type {type(topic)} does not support drafts")
-        return super().is_applicable_to(identity, topic, *args, **kwargs)
+        if isinstance(topic, Draft):
+            return topic
+        service = cast("RecordService", current_runtime.get_record_service_for_record(topic))
+        try:
+            return cast("Draft", record_from_result(service.read_draft(identity, topic["id"])))
+        except Exception as e:
+            raise ValueError(f"Failed to read draft for topic {topic}") from e
 
     def assert_no_pending_requests(
         self,

--- a/oarepo_requests/types/publish_changed_metadata.py
+++ b/oarepo_requests/types/publish_changed_metadata.py
@@ -29,6 +29,25 @@ class PublishChangedMetadataRequestType(PublishRequestType):
     type_id = "publish_changed_metadata"
     name = _("Publish changed metadata")
 
+    @override
+    def can_create(
+        self,
+        identity: Identity,
+        data: dict,
+        receiver: dict[str, str],
+        topic: Record,
+        creator: dict[str, str],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Check if the request can be created."""
+        topic = self._convert_to_draft(identity, topic)
+        if self.topic_type(topic) != "metadata":
+            raise ValueError(
+                f"Topic type {self.topic_type(topic)} is not a draft for changed metadata of a published record"
+            )
+        super().can_create(identity, data, receiver, topic, creator, *args, **kwargs)
+
     @classmethod
     def is_applicable_to(cls, identity: Identity, topic: Record, *args: Any, **kwargs: Any) -> bool:
         """Check if the request type is applicable to the topic."""

--- a/oarepo_requests/types/publish_changed_metadata.py
+++ b/oarepo_requests/types/publish_changed_metadata.py
@@ -32,6 +32,7 @@ class PublishChangedMetadataRequestType(PublishRequestType):
     @classmethod
     def is_applicable_to(cls, identity: Identity, topic: Record, *args: Any, **kwargs: Any) -> bool:
         """Check if the request type is applicable to the topic."""
+        topic = cls._convert_to_draft(identity, topic)
         if cls.topic_type(topic) != "metadata":
             return False
 

--- a/oarepo_requests/types/publish_draft.py
+++ b/oarepo_requests/types/publish_draft.py
@@ -38,6 +38,23 @@ class PublishDraftRequestType(PublishRequestType):
         "version": ma.fields.Str(),
     }
 
+    @override
+    def can_create(
+        self,
+        identity: Identity,
+        data: dict,
+        receiver: dict[str, str],
+        topic: Record,
+        creator: dict[str, str],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Check if the request can be created."""
+        topic = self._convert_to_draft(identity, topic)
+        if self.topic_type(topic) != "initial":
+            raise ValueError(f"Topic type {self.topic_type(topic)} is not the initial unpublished draft")
+        super().can_create(identity, data, receiver, topic, creator, *args, **kwargs)
+
     @classmethod
     def is_applicable_to(cls, identity: Identity, topic: Record, *args: Any, **kwargs: Any) -> bool:
         """Check if the request type is applicable to the topic."""

--- a/oarepo_requests/types/publish_draft.py
+++ b/oarepo_requests/types/publish_draft.py
@@ -41,6 +41,7 @@ class PublishDraftRequestType(PublishRequestType):
     @classmethod
     def is_applicable_to(cls, identity: Identity, topic: Record, *args: Any, **kwargs: Any) -> bool:
         """Check if the request type is applicable to the topic."""
+        topic = cls._convert_to_draft(identity, topic)
         if cls.topic_type(topic) != "initial":
             return False
 

--- a/oarepo_requests/types/publish_new_version.py
+++ b/oarepo_requests/types/publish_new_version.py
@@ -80,6 +80,7 @@ class PublishNewVersionRequestType(PublishRequestType):
     @classmethod
     def is_applicable_to(cls, identity: Identity, topic: Record, *args: Any, **kwargs: Any) -> bool:
         """Check if the request type is applicable to the topic."""
+        topic = cls._convert_to_draft(identity, topic)
         if cls.topic_type(topic) != "new_version":
             return False
 

--- a/oarepo_requests/types/publish_new_version.py
+++ b/oarepo_requests/types/publish_new_version.py
@@ -62,6 +62,10 @@ class PublishNewVersionRequestType(PublishRequestType):
         **kwargs: Any,
     ) -> None:
         """Check if the request can be created."""
+        topic = self._convert_to_draft(identity, topic)
+        if self.topic_type(topic) != "new_version":
+            raise ValueError(f"Topic type {self.topic_type(topic)} is not a draft of a new version of a record")
+
         topic_service = get_draft_record_service(topic)
         # Only needed in case of new version as when you are publishing
         # draft for the first time, there are no previous versions with


### PR DESCRIPTION
## Fix draft resolution in PublishChangedMetadata requests

Drafts and published records in Invenio share the same entity resolver. Both are serialized as:

```python
{"record": <id>}
```

where `<id>` is the same for the draft and the published record.

When Invenio resolves such a reference and a published variant exists, the published record takes priority. This causes a problem in `PublishChangedMetadata` requests, where the request must re-publish the draft version of an already published record.

This PR fixes the issue by always converting the resolved record to its draft variant and using that for the publish operation.
